### PR TITLE
feat(shell): support zsh

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 func check(e error) {
@@ -12,9 +14,29 @@ func check(e error) {
 	}
 }
 
+func getRcFilePath() (string, error) {
+	shell := os.Getenv("SHELL")
+
+	switch {
+	case strings.Contains(shell, "bash"):
+		return "/.bashrc", nil
+	case strings.Contains(shell, "zsh"):
+		return "/.zshrc", nil
+	default:
+		var errMsg = fmt.Sprintf("Unsupported shell %s", shell)
+		return "", errors.New(errMsg)
+	}
+}
+
 func main() {
 
 	args := os.Args[1:]
+
+	rcFilePath, err := getRcFilePath()
+
+	if err != nil {
+		panic(err)
+	}
 
 	if len(args) >= 2 {
 
@@ -26,7 +48,7 @@ func main() {
 
 		home := os.Getenv("HOME")
 
-		bashRcFileLocation := home + "/.bashrc"
+		bashRcFileLocation := home + rcFilePath
 
 		bashRcFile, err := os.OpenFile(bashRcFileLocation, os.O_APPEND|os.O_WRONLY, 0644)
 		check(err)


### PR DESCRIPTION
This PR adds support for the ```zsh``` shell. I was unable to access ```$0``` using the advice from https://github.com/pushkar-anand/bashAliasCreator/issues/1, so I used ```$SHELL``` instead. Note that a consequence of this is that nested shells are not supported. For example, if you use zsh, but within zsh you run ```exec bash```, this will open up a bash shell nested within the zsh shell. But from within that bash shell, if you run bashAliasCreator, it will still edit your ```.zshrc```, not your ```.bashrc```, because ```$SHELL``` still points to the path of your zsh source even though ```$0``` is ```bash``` at that point.